### PR TITLE
Add force retry mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Format:
         buffer_path /var/log/fluent/redshift
         flush_interval 15m
         buffer_chunk_limit 1g
+        force_retry_flg_path /your/config/maintenance_flg
     </match>
 
 Example (watch and upload json formatted apache log):
@@ -126,6 +127,8 @@ Example (watch and upload json formatted apache log):
 + `buffer_chunk_limit` : limit buffer size to chunk.
 
 + `utc` : utc time zone. This parameter affects `timestamp_key_format`.
+
++ `force_retry_flg_path` : path of force retry flag. plugin does not try to logging and retry after it while given file exists.
 
 ## Logging examples
 ```ruby

--- a/lib/fluent/plugin/out_redshift.rb
+++ b/lib/fluent/plugin/out_redshift.rb
@@ -37,6 +37,7 @@ class RedshiftOutput < BufferedOutput
   config_param :redshift_schemaname, :string, :default => nil
   config_param :redshift_copy_base_options, :string , :default => "FILLRECORD ACCEPTANYDATE TRUNCATECOLUMNS"
   config_param :redshift_copy_options, :string , :default => nil
+  config_param :force_retry_flg_path, :string, :default => nil
   # file format
   config_param :file_type, :string, :default => nil  # json, tsv, csv, msgpack
   config_param :delimiter, :string, :default => nil
@@ -83,6 +84,10 @@ class RedshiftOutput < BufferedOutput
   end
 
   def write(chunk)
+    if @force_retry_flg_path && File.exist?(@force_retry_flg_path)
+      raise "Forced to retry mode by #{@force_retry_flg_path}"
+    end
+
     $log.debug format_log("start creating gz.")
 
     # create a gz file

--- a/test/plugin/test_out_redshift.rb
+++ b/test/plugin/test_out_redshift.rb
@@ -523,4 +523,23 @@ class RedshiftOutputTest < Test::Unit::TestCase
     emit_json(d_json)
     assert_equal true, d_json.run
   end
+
+  def test_write_with_json_with_force_retry_mode
+    setup_mocks(%[val_a\tval_b\t\t\t\t\t\t\n\t\tval_c\tval_d\t\t\t\t\nval_a\tval_b\t\t\t\t\t\t\n\t\tval_c\tval_d\t\t\t\t\n])
+
+    file = Tempfile.new('fluentd-redshift-plugin-test')
+    d_json = create_driver(%[
+      #{CONFIG_JSON}
+      force_retry_flg_path #{file.path}
+    ])
+    emit_json(d_json)
+    assert_raise(RuntimeError, "Forced to retry mode by #{file.path}") {
+      d_json.run
+    }
+
+    file.delete
+
+    emit_json(d_json)
+    assert_equal true, d_json.run
+  end
 end


### PR DESCRIPTION
## Overview
Add 'force retry mode' for redshift maintenances. This mode makes log queue retry without trying to save redshift.

## Background
Redshift often goes down for maintenance. We can execute copy query while maintenance, but we can not load these data after that. No one guarantees behaviors while maintenance.

## Purpose
This 'force retry mode' brings us a controllable way while redshift downtime. If we set this option with ```retry_limit```  and ```retry_wait```, fluentd buffers queues while flag file existing, so that we don't have to re-copy from S3 manually after maintenance.

@mmasashi 
how does it sound to you?