### PR TITLE
aws-sdk -> aws-sdk-v1

### DIFF
--- a/fluent-plugin-redshift.gemspec
+++ b/fluent-plugin-redshift.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "fluentd", "~> 0.10.0"
-  gem.add_dependency "aws-sdk", ">= 1.6.3"
+  gem.add_dependency "aws-sdk-v1", ">= 1.6.3"
   gem.add_dependency "pg", "~> 0.17.0"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "simplecov", ">= 0.5.4"

--- a/lib/fluent/plugin/out_redshift.rb
+++ b/lib/fluent/plugin/out_redshift.rb
@@ -9,7 +9,7 @@ class RedshiftOutput < BufferedOutput
 
   def initialize
     super
-    require 'aws-sdk'
+    require 'aws-sdk-v1'
     require 'zlib'
     require 'time'
     require 'tempfile'


### PR DESCRIPTION
Codes are currently not compatible with `aws-sdk` v2. Should depend on and require `aws-sdk-v1`.