### PR TITLE
Fix error handling when recieved broken data.

### DIFF
--- a/lib/fluent/plugin/out_redshift.rb
+++ b/lib/fluent/plugin/out_redshift.rb
@@ -171,6 +171,7 @@ class RedshiftOutput < BufferedOutput
     begin
       gzw = Zlib::GzipWriter.new(dst_file)
       chunk.msgpack_each do |record|
+        next unless record
         begin
           hash = json? ? json_to_hash(record[@record_log_tag]) : record[@record_log_tag]
           tsv_text = hash_to_table_text(redshift_table_columns, hash, delimiter)
@@ -230,6 +231,7 @@ class RedshiftOutput < BufferedOutput
     JSON.parse(json_text)
   rescue => e
     $log.warn format_log("failed to parse json. "), :error => e.to_s
+    nil
   end
 
   def hash_to_table_text(redshift_table_columns, hash, delimiter)


### PR DESCRIPTION
Thank you for your plugin. I'm using this plugin always.
But, I have problem.
When receiving the broken data can not handle the error.

ex) `{"name":"taro", "gender": "male", "categÎTF=L£logÚ¼ÀÀÀÀÀ£lo`

So, I fixed it.  :)