### PR TITLE
Support secret parameters

### DIFF
--- a/lib/fluent/plugin/out_redshift.rb
+++ b/lib/fluent/plugin/out_redshift.rb
@@ -22,8 +22,8 @@ class RedshiftOutput < BufferedOutput
 
   config_param :record_log_tag, :string, :default => 'log'
   # s3
-  config_param :aws_key_id, :string
-  config_param :aws_sec_key, :string
+  config_param :aws_key_id, :string, :secret => true
+  config_param :aws_sec_key, :string, :secret => true
   config_param :s3_bucket, :string
   config_param :s3_endpoint, :string, :default => nil
   config_param :path, :string, :default => ""
@@ -34,7 +34,7 @@ class RedshiftOutput < BufferedOutput
   config_param :redshift_port, :integer, :default => 5439
   config_param :redshift_dbname, :string
   config_param :redshift_user, :string
-  config_param :redshift_password, :string
+  config_param :redshift_password, :string, :secret => true
   config_param :redshift_tablename, :string
   config_param :redshift_schemaname, :string, :default => nil
   config_param :redshift_copy_base_options, :string , :default => "FILLRECORD ACCEPTANYDATE TRUNCATECOLUMNS"


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
This feature will work as below:

```log
  <match my.tag>
    type redshift
    aws_key_id xxxxxx # :secret => true in config_param
    aws_sec_key xxxxxx # :secret => true in config_param
    s3_bucket YOUR_S3_BUCKET
    s3_endpoint YOUR_S3_BUCKET_END_POINT
    path YOUR_S3_PATH
    timestamp_key_format year=%Y/month=%m/day=%d/hour=%H/%Y%m%d-%H%M
    redshift_host YOUR_AMAZON_REDSHIFT_CLUSTER_END_POINT
    redshift_port YOUR_AMAZON_REDSHIFT_CLUSTER_PORT
    redshift_dbname YOUR_AMAZON_REDSHIFT_CLUSTER_DATABASE_NAME
    redshift_user YOUR_AMAZON_REDSHIFT_CLUSTER_USER_NAME
    redshift_password xxxxxx # :secret => true in config_param
    redshift_schemaname YOUR_AMAZON_REDSHIFT_CLUSTER_TARGET_SCHEMA_NAME
    redshift_tablename YOUR_AMAZON_REDSHIFT_CLUSTER_TARGET_TABLE_NAME
    file_type tsv
    buffer_type file
    buffer_path /var/log/fluent/redshift
    flush_interval 15m
    buffer_chunk_limit 1g
    maintenance_file_path /path/to/maintenance_file
  </match>
</ROOT>
```

But for now, this plugin depends fluentd 0.10 series.
Thus, this parameters will be simply ignored.