### PR TITLE
Loosen fluentd dependency

### DIFF
--- a/fluent-plugin-redshift.gemspec
+++ b/fluent-plugin-redshift.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "fluentd", "~> 0.10.0"
+  gem.add_dependency "fluentd", [">= 0.10.0", "< 2"]
   gem.add_dependency "aws-sdk-v1", ">= 1.6.3"
   gem.add_dependency "pg", "~> 0.17.0"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
When using fluentd 0.12.15, all tests passed.

Fluentd 0.12 series has been introduced various useful features:

ref: http://www.fluentd.org/blog/fluentd-v0.12-is-released

* v1 config
* label 
* filter plugins
* secret parameters (Fully supported since 0.12.13 or later)

and so on.